### PR TITLE
Adds support for non US dataset locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.4
+- Adds support for data in non-US regions
+
+## 0.0.3
+- Fixes bug where queries returning zero rows throw an error
+
 ## 0.0.2
 - Fixes bugs with sidebar explorer
 - Implements ability to view table results from explorer

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # SQLTools BigQuery Driver
 
-A Visual Studio Code extension which extends [SQLTools](https://marketplace.visualstudio.com/items?itemName=mtxr.sqltools), with a driver for Google BigQuery. 
+A Visual Studio Code extension that extends [SQLTools](https://marketplace.visualstudio.com/items?itemName=mtxr.sqltools), with a driver for Google BigQuery. 
+
+This driver is maintained by [Evidence](https://evidence.dev): an open source BI tool to publish reports with SQL and Markdown.
 
 ![Connect DB](docs/images/connect-db.gif)
 
@@ -36,16 +38,12 @@ Supports the following connection methods:
 For more details on the above connection methods see [connection guides](https://docs.evidence.dev/core-concepts/data-sources/#bigquery).
 
 ## ToDo
-- Fix issue causing `connection-name.session.sql` file to be opened
-- Add BigQuery specific keywords
+- Add BigQuery-specific keywords
 - IntelliSense for table and column completion
-
 
 ## Maintained by [<img src="docs/images/evidence.png"  style="height:1em;"/>](https://www.evidence.dev)
 
-This extension is a free, open source community project, maintained by [Evidence.dev](https://www.evidence.dev).
-
-Evidence is an open source publishing tool for modern data teams, allowing you to build polished data products with just SQL and markdown.
+Evidence is an open-source publishing tool for modern data teams, allowing you to build polished data products with just SQL and markdown.
 - Star us on [GitHub](https://github.com/evidence-dev/evidence)
 - Read our [Docs](https://docs.evidence.dev)
 - Join us on [Slack](https://join.slack.com/t/evidencedev/shared_invite/zt-uda6wp6a-hP6Qyz0LUOddwpXW5qG03Q)

--- a/connection.schema.json
+++ b/connection.schema.json
@@ -22,6 +22,12 @@
         "GCloud CLI"
       ],
       "default": "SERVICE_ACCOUNT"
+    },
+    "location": {
+      "title": "Location",
+      "type": "string",
+      "minLength": 1,
+      "default": "us"
     }
   },
   "dependencies": {
@@ -41,7 +47,7 @@
             }
           },
           "required": [
-            "authenticator", "keyfile"
+            "authenticator", "keyfile", "location"
           ]
         },
         {
@@ -63,7 +69,7 @@
             }
           },
           "required": [
-            "authenticator", "token", "projectId"
+            "authenticator", "token", "projectId", "location"
           ]
         },
         {
@@ -80,7 +86,7 @@
             }
           },
           "required": [
-            "authenticator", "projectId"
+            "authenticator", "projectId", "location"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sqltools-bigquery-driver",
   "displayName": "BigQuery Driver for SQLTools",
   "description": "Run Queries and Explore your BigQuery Database in VSCode",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "engines": {
     "vscode": "^1.42.0"
   },

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -29,10 +29,13 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
 
   public async open() {
     const getCredentials = () => {
+
+      
       const authentication_method = this.credentials.authenticator
       if (authentication_method === 'CLI') {
         return {
-          projectId: this.credentials.projectId
+          projectId: this.credentials.projectId,
+          location: this.credentials.location
         };
       } else if (authentication_method === 'OAUTH') {
         // currently causing error
@@ -43,12 +46,14 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
         return {
           // is this a legit way to handle this typescript error
           authClient: oauth as JSONClient,
-          projectId: this.credentials.projectId
+          projectId: this.credentials.projectId,
+          location: this.credentials.location
         };
       } else {
         console.log('keyfile', this.credentials.keyfile)
         return {
-          keyFilename: this.credentials.keyfile
+          keyFilename: this.credentials.keyfile,
+          location: this.credentials.location
         }
       };
     }
@@ -57,6 +62,7 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
 
     this.connection = new Promise((resolve, reject) => {
       try {
+        console.log('connOptions', connOptions)
         const bigquery = new BigQuery({ ...connOptions, maxRetries: 10 });
         resolve(bigquery);
       } catch (error) {
@@ -91,6 +97,7 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
     const options = {
       // typescript complains if this is not an array
       query: [query],
+      location: this.credentials.location,
     };
     const resultsAgg: NSDatabase.IResult[] = [];
 

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -38,7 +38,6 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
           location: this.credentials.location
         };
       } else if (authentication_method === 'OAUTH') {
-        // currently causing error
         const access_token = this.credentials.token;
         const oauth = new OAuth2Client();
         oauth.setCredentials({ access_token });
@@ -50,7 +49,6 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
           location: this.credentials.location
         };
       } else {
-        console.log('keyfile', this.credentials.keyfile)
         return {
           keyFilename: this.credentials.keyfile,
           location: this.credentials.location
@@ -62,7 +60,6 @@ export default class BigQueryDriver extends AbstractDriver<DriverLib, DriverOpti
 
     this.connection = new Promise((resolve, reject) => {
       try {
-        console.log('connOptions', connOptions)
         const bigquery = new BigQuery({ ...connOptions, maxRetries: 10 });
         resolve(bigquery);
       } catch (error) {

--- a/src/ls/queries.ts
+++ b/src/ls/queries.ts
@@ -40,7 +40,6 @@ const countRecords: IBaseQueries['countRecords'] = queryFactory`
   FROM \`${p => p.table.schema}.${p => p.table.label}\`
 `;
 
-// BigQuery throws an error if you return an empty result set from the information schema
 const fetchTablesAndViews = (
   type: ContextValue,
   tableType: string

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -16,6 +16,9 @@
   },
   "token": {
     "ui:widget": "password"
+  },
+  "location": {
+    "ui:help": "Default `us`. Each connection can access one location. Full location list: https://cloud.google.com/bigquery/docs/locations"
   }
 
 }


### PR DESCRIPTION
Addresses #4 

This adds a `Location` field to the connection manager, where you can add a location identifier to specify where your data is located. 

The list of supported BQ locations is here: https://cloud.google.com/bigquery/docs/locations

To view datasets in mutliple locations, you should create multiple connections with different regions specified